### PR TITLE
unix socket を使って manager のポート指定をやめる

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,13 @@ services:
     build: manager
     environment:
       PORT: 8080
+      SOCKET: /run/manager.sock
       DATABASE_URL: postgres://ztp:ztp@db:5432/ztp?sslmode=disable
       NODE_MODULE: pg
     ports:
-      - 8080:8080
+      - 8080
+    volumes:
+      - run:/run:ro
   db:
     image: postgres:9.6-alpine
     environment:
@@ -18,7 +21,7 @@ services:
     build: dhcpd
     network_mode: host
     environment:
-      API_URL: http://localhost:8080/api
+      API_URL: unix://run/manager.sock/api
       DHCP_SERVER_IP_ADDR: 172.17.4.50
       DHCP_START_IP_ADDR: 172.17.4.100
       DHCP_LEASE_RANGE: 150
@@ -33,3 +36,7 @@ services:
         DomainName: domain.tld
     ports:
       - 67:67/udp
+    volumes:
+      - run:/run:ro
+volumes:
+  run:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - 8080
     volumes:
-      - run:/run:ro
+      - run:/run
   db:
     image: postgres:9.6-alpine
     environment:


### PR DESCRIPTION
hostネットワークと通信するのにunix socketを使うようにした

ref: https://github.com/kstm-su/ool-specialist-2017/issues/12