### PR TITLE
Remove argument for hyperkit

### DIFF
--- a/storage/image.go
+++ b/storage/image.go
@@ -81,7 +81,7 @@ func (i *Image) Build() error {
 		return err
 	}
 
-	if err := moby.Formats(path+"/linuxkit", buf.Bytes(), imageTypes, i.Size, false); err != nil {
+	if err := moby.Formats(path+"/linuxkit", buf.Bytes(), imageTypes, i.Size); err != nil {
 		errStr := err.Error()
 		i.Error = &errStr
 		return err


### PR DESCRIPTION
## WHY

An argument for `hyperkit` removed from `moby/tool`.

https://github.com/moby/tool/commit/aca26f00c21385cd4f4daf00c14f7f5e05fecbf5#diff-919b626579e0b0f090ee4a4b35729514

## WHAT

followed this.