### PR TITLE
Change using image owner from ugwis to kstm organization

### DIFF
--- a/manager/standby.conf
+++ b/manager/standby.conf
@@ -15,7 +15,7 @@ services:
     env:
      - INSECURE=true
   - name: standby
-    image: ugwis/standby
+    image: kstm/ztp:standby
     env:
      - DHCP_START_IP_ADDR=${start_ip}
      - DHCP_LEASE_RANGE=${lease_range}
@@ -24,4 +24,4 @@ trust:
   org:
     - linuxkit
   image:
-    - ugwis/standby
+    - kstm/ztp:standby


### PR DESCRIPTION
## WHY
- Because previous PR (https://github.com/kstm-su/ztp/pull/31) create image with tag (kstm/ztp:standby)

## WHAT
- Enable automatic build image with tag on docker cloud
- Change using image path