### PR TITLE
Reuse IP address

### DIFF
--- a/dhcp/.dockerignore
+++ b/dhcp/.dockerignore
@@ -1,2 +1,3 @@
 *
 !main.go
+!server/*.go

--- a/dhcp/main.go
+++ b/dhcp/main.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/bgpat/dhcpd/server"
 	dhcp "github.com/krolaw/dhcp4"
+	"github.com/kstm-su/ztp/dhcp/server"
 	"github.com/parnurzeal/gorequest"
 )
 

--- a/dhcp/main.go
+++ b/dhcp/main.go
@@ -55,9 +55,8 @@ func main() {
 				if lease.IPAddr == nil {
 					nodeIP := net.ParseIP(node.IPAddress)
 					if nodeIP == nil {
-						lease.Find()
-						if lease == nil {
-							fmt.Println(err)
+						if !lease.Find() {
+							fmt.Println("No IP pool space available")
 							return &server.NAKReply{}
 						}
 					} else {

--- a/dhcp/main.go
+++ b/dhcp/main.go
@@ -63,6 +63,7 @@ func main() {
 						}
 					} else {
 						lease.IPAddr = nodeIP
+						lease.Update()
 					}
 				}
 				reply := &server.ACKReply{

--- a/dhcp/main.go
+++ b/dhcp/main.go
@@ -53,6 +53,18 @@ func main() {
 		for _, node := range nodes {
 			if strings.ToLower(node.MACAddress) == macAddr {
 				fmt.Printf("node: %+v\n", node)
+				if lease.IPAddr == nil {
+					nodeIP := net.ParseIP(node.IPAddress)
+					if nodeIP == nil {
+						lease.Find()
+						if lease == nil {
+							fmt.Println(err)
+							return &server.NAKReply{}
+						}
+					} else {
+						lease.IPAddr = nodeIP
+					}
+				}
 				reply := &server.ACKReply{
 					Lease: lease,
 					Options: dhcp.Options{
@@ -66,7 +78,12 @@ func main() {
 				return reply
 			}
 		}
-		fmt.Println("It's booted from the standby image")
+		fmt.Println("unknown MAC address: ", macAddr)
+		lease.Find()
+		if lease == nil {
+			fmt.Println(err)
+			return &server.NAKReply{}
+		}
 		reply := &server.ACKReply{
 			Lease: lease,
 			Options: dhcp.Options{

--- a/dhcp/main.go
+++ b/dhcp/main.go
@@ -64,6 +64,9 @@ func main() {
 						lease.Update()
 					}
 				}
+				if node.Image.Path == "" {
+					node.Image = images[0]
+				}
 				reply := &server.ACKReply{
 					Lease: lease,
 					Options: dhcp.Options{

--- a/dhcp/server/config.go
+++ b/dhcp/server/config.go
@@ -39,7 +39,7 @@ func NewConfig() (*Config, error) {
 	return &c, nil
 }
 
-func (c *Config) Server(change func(*Lease) Reply) *Server {
+func (c *Config) Server(handler func(*Lease) Reply) *Server {
 	return &Server{
 		Handler: &Handler{
 			ServerIPAddr: net.ParseIP(c.Server_IP_Addr).To4(),
@@ -49,7 +49,7 @@ func (c *Config) Server(change func(*Lease) Reply) *Server {
 				Range:       c.Lease_Range,
 				Duration:    c.Lease_Duration,
 			},
-			Change: change,
+			handlerFunc: handler,
 		},
 		Interface: c.Interface,
 	}

--- a/dhcp/server/config.go
+++ b/dhcp/server/config.go
@@ -44,7 +44,7 @@ func (c *Config) Server(handler func(*Lease) Reply) *Server {
 		Handler: &Handler{
 			ServerIPAddr: net.ParseIP(c.Server_IP_Addr).To4(),
 			Options:      dhcp.Options(c.Options),
-			Leases: Leases{
+			Leases: &Leases{
 				StartIPAddr: net.ParseIP(c.Start_IP_Addr).To4(),
 				Range:       c.Lease_Range,
 				Duration:    c.Lease_Duration,

--- a/dhcp/server/config.go
+++ b/dhcp/server/config.go
@@ -1,0 +1,252 @@
+package server
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/kelseyhightower/envconfig"
+	dhcp "github.com/krolaw/dhcp4"
+	"gopkg.in/yaml.v2"
+)
+
+type Config struct {
+	Interface      *string
+	Server_IP_Addr string `required:"true"`
+	Options        OptionsDecoder
+	Start_IP_Addr  string        `required:"true"`
+	Lease_Range    int           `required:"true"`
+	Lease_Duration time.Duration `default:"1h"`
+}
+
+type OptionsDecoder dhcp.Options
+
+type IPDecoder net.IP
+
+type CIDRDecoder []byte
+
+type DomainNameDecoder []byte
+
+func NewConfig() (*Config, error) {
+	c := Config{
+		Options: make(OptionsDecoder),
+	}
+	if err := envconfig.Process("dhcp", &c); err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+func (c *Config) Server(change func(*Lease) Reply) *Server {
+	return &Server{
+		Handler: &Handler{
+			ServerIPAddr: net.ParseIP(c.Server_IP_Addr).To4(),
+			Options:      dhcp.Options(c.Options),
+			Leases: Leases{
+				StartIPAddr: net.ParseIP(c.Start_IP_Addr).To4(),
+				Range:       c.Lease_Range,
+				Duration:    c.Lease_Duration,
+			},
+			Change: change,
+		},
+		Interface: c.Interface,
+	}
+}
+
+func (o *OptionsDecoder) Decode(s string) error {
+	labels := make(map[string]int)
+	for i := 1; i < 0xff; i++ {
+		key := strings.TrimSuffix(strings.TrimPrefix(strings.TrimPrefix(dhcp.OptionCode(i).String(), "Option"), "Code("), ")")
+		labels[key] = i
+	}
+	obj := make(map[string]interface{})
+	if err := yaml.Unmarshal([]byte(s), &obj); err != nil {
+		return err
+	}
+	options := make(dhcp.Options)
+	for key, val := range obj {
+		code, err := strconv.Atoi(key)
+		if err != nil {
+			var ok bool
+			code, ok = labels[key]
+			if !ok {
+				continue
+			}
+		}
+		var buf []byte
+		switch code {
+		case 1, 16, 28, 32, 50, 54, 78, 95: // net.IP
+			s, ok := val.(string)
+			if !ok {
+				return fmt.Errorf("invalid format %s(%T)", dhcp.OptionCode(code).String(), val)
+			}
+			buf = net.ParseIP(s).To4()
+		case 3, 4, 5, 6, 7, 8, 9, 10, 11, 41, 42, 44, 45, 48, 49, 65, 68, 69, 70, 71, 72, 73, 74, 75, 76, 92, 112, 118, 138, 150: // []net.IP
+			list, ok := val.([]interface{})
+			if !ok {
+				return fmt.Errorf("invalid format %s(%T)", dhcp.OptionCode(code).String(), val)
+			}
+			buf = []byte{}
+			for _, v := range list {
+				s, ok := v.(string)
+				if !ok {
+					return fmt.Errorf("invalid format %s(%T)", dhcp.OptionCode(code).String(), val)
+				}
+				buf = append(buf, net.ParseIP(strings.TrimSpace(s)).To4()...)
+			}
+		case 21, 33: // [][2]net.IP
+			list, ok := val.([]interface{})
+			if !ok {
+				return fmt.Errorf("invalid format %s(%T)", dhcp.OptionCode(code).String(), val)
+			}
+			buf = []byte{}
+			for _, v := range list {
+				s, ok := v.(string)
+				if !ok {
+					return fmt.Errorf("invalid format %s(%T)", dhcp.OptionCode(code).String(), val)
+				}
+				pair := strings.SplitN(strings.TrimSpace(s), " ", 2)
+				addr := net.ParseIP(pair[0]).To4()
+				mask := net.ParseIP(pair[1]).To4()
+				buf = append(buf, addr...)
+				buf = append(buf, mask...)
+			}
+		case 121: // CIDR
+			list, ok := val.([]interface{})
+			if !ok {
+				return fmt.Errorf("invalid format %s(%T)", dhcp.OptionCode(code).String(), val)
+			}
+			buf = []byte{}
+			for _, v := range list {
+				s, ok := v.(string)
+				if !ok {
+					return fmt.Errorf("invalid format %s(%T)", dhcp.OptionCode(code).String(), val)
+				}
+				pair := strings.SplitN(strings.TrimSpace(s), " ", 2)
+				dst := CIDRDecoder{}
+				if err := dst.Decode(pair[0]); err != nil {
+					return err
+				}
+				gw := net.ParseIP(pair[1]).To4()
+				buf = append(buf, []byte(dst)...)
+				buf = append(buf, gw...)
+			}
+		case 119: // Domain Name
+			list, ok := val.([]interface{})
+			if !ok {
+				return fmt.Errorf("invalid format %s(%T)", dhcp.OptionCode(code).String(), val)
+			}
+			buf = []byte{}
+			for _, v := range list {
+				s, ok := v.(string)
+				if !ok {
+					return fmt.Errorf("invalid format %s(%T)", dhcp.OptionCode(code).String(), val)
+				}
+				decoder := DomainNameDecoder{}
+				if err := decoder.Decode(s); err != nil {
+					return err
+				}
+				buf = append(buf, []byte(decoder)...)
+			}
+		case 2: // time.Duration (int32)
+			s, ok := val.(string)
+			if !ok {
+				return fmt.Errorf("invalid format %s(%T)", dhcp.OptionCode(code).String(), val)
+			}
+			duration, err := time.ParseDuration(s)
+			if err != nil {
+				return err
+			}
+			i := int32(duration.Seconds())
+			buf = []byte{byte(i >> 24), byte(i >> 16), byte(i >> 8), byte(i)}
+		case 24, 35, 38, 51, 58, 59, 91: // time.Duration (uint32)
+			s, ok := val.(string)
+			if !ok {
+				return fmt.Errorf("invalid format %s(%T)", dhcp.OptionCode(code).String(), val)
+			}
+			duration, err := time.ParseDuration(s)
+			if err != nil {
+				return err
+			}
+			i := uint32(duration.Seconds())
+			buf = []byte{byte(i >> 24), byte(i >> 16), byte(i >> 8), byte(i)}
+		case 19, 20, 27, 29, 30, 31, 34, 36, 39: // bool
+			s, ok := val.(string)
+			if !ok {
+				return fmt.Errorf("invalid format %s(%T)", dhcp.OptionCode(code).String(), val)
+			}
+			if s == "1" || s == "yes" || s == "true" {
+				buf = []byte{1}
+			} else {
+				buf = []byte{0}
+			}
+		case 23, 37, 46, 52, 53, 116: // byte
+			n, ok := val.(byte)
+			if !ok {
+				return fmt.Errorf("invalid format %s(%T)", dhcp.OptionCode(code).String(), val)
+			}
+			buf = []byte{byte(n)}
+		case 13, 22, 26, 57, 93: // uint16
+			n, ok := val.(uint16)
+			if !ok {
+				return fmt.Errorf("invalid format %s(%T)", dhcp.OptionCode(code).String(), val)
+			}
+			buf = []byte{byte(n >> 8), byte(n)}
+		case 25: // []uint16
+			list, ok := val.([]uint16)
+			if !ok {
+				return fmt.Errorf("invalid format %s(%T)", dhcp.OptionCode(code).String(), val)
+			}
+			buf = []byte{}
+			for _, n := range list {
+				buf = append(buf, []byte{byte(n >> 8), byte(n)}...)
+			}
+		default: // string
+			s, ok := val.(string)
+			if !ok {
+				return fmt.Errorf("invalid format %s(%T)", dhcp.OptionCode(code).String(), val)
+			}
+			buf = []byte(s)
+		}
+		options[dhcp.OptionCode(code)] = buf
+	}
+	*o = OptionsDecoder(options)
+	return nil
+}
+
+func (ip *IPDecoder) Decode(s string) error {
+	*ip = IPDecoder(net.ParseIP(s))
+	return nil
+}
+
+func (cidr *CIDRDecoder) Decode(s string) error {
+	_, ip, err := net.ParseCIDR(s)
+	if err != nil {
+		return err
+	}
+	mask, _ := ip.Mask.Size()
+	size := (mask + 7) >> 3
+	buf := make([]byte, size+1)
+	buf[0] = byte(mask)
+	for i := 0; i < size; i++ {
+		buf[i+1] = []byte(ip.IP)[i]
+	}
+	*cidr = CIDRDecoder(buf)
+	return nil
+}
+
+func (d *DomainNameDecoder) Decode(s string) error {
+	buf := []byte{}
+	for _, sub := range strings.Split(s, ".") {
+		if len(sub) <= 0 {
+			return fmt.Errorf(`"%s" is invalid domain name`, s)
+		}
+		buf = append(buf, byte(len(sub)))
+		buf = append(buf, []byte(sub)...)
+	}
+	buf = append(buf, 0)
+	*d = DomainNameDecoder(buf)
+	return nil
+}

--- a/dhcp/server/handler.go
+++ b/dhcp/server/handler.go
@@ -12,7 +12,7 @@ type Handler struct {
 	ServerIPAddr net.IP
 	Options      dhcp.Options
 	Leases       Leases
-	Change       func(*Lease) Reply
+	handlerFunc  func(*Lease) Reply
 }
 
 var processing = map[dhcp.MessageType]map[string]struct{}{}
@@ -34,8 +34,8 @@ func (h *Handler) ServeDHCP(p dhcp.Packet, msgType dhcp.MessageType, options dhc
 		if lease == nil {
 			break
 		}
-		if h.Change != nil {
-			if reply := h.Change(lease); reply != nil {
+		if h.handlerFunc != nil {
+			if reply := h.handlerFunc(lease); reply != nil {
 				replyPacket = reply.Packet(p, msgType, h, options[dhcp.OptionParameterRequestList])
 				break
 			}
@@ -71,8 +71,8 @@ func (h *Handler) ServeDHCP(p dhcp.Packet, msgType dhcp.MessageType, options dhc
 			break
 		}
 		lease.Expiry = time.Now().Add(h.Leases.Duration)
-		if h.Change != nil {
-			if reply := h.Change(lease); reply != nil {
+		if h.handlerFunc != nil {
+			if reply := h.handlerFunc(lease); reply != nil {
 				replyPacket = reply.Packet(p, msgType, h, options[dhcp.OptionParameterRequestList])
 				break
 			}

--- a/dhcp/server/handler.go
+++ b/dhcp/server/handler.go
@@ -94,6 +94,8 @@ func (h *Handler) ServeDHCP(p dhcp.Packet, msgType dhcp.MessageType, options dhc
 		h.Leases.Delete(p.CHAddr())
 	}
 	delete(processing[msgType], p.CHAddr().String())
-	replyPacket.SetSIAddr(h.ServerIPAddr)
+	if len(replyPacket) > 0 {
+		replyPacket.SetSIAddr(h.ServerIPAddr)
+	}
 	return
 }

--- a/dhcp/server/handler.go
+++ b/dhcp/server/handler.go
@@ -17,15 +17,13 @@ type Handler struct {
 
 var processing = map[dhcp.MessageType]map[string]struct{}{}
 
-func init() {
-	processing[dhcp.Discover] = map[string]struct{}{}
-	processing[dhcp.Request] = map[string]struct{}{}
-}
-
 func (h *Handler) ServeDHCP(p dhcp.Packet, msgType dhcp.MessageType, options dhcp.Options) (replyPacket dhcp.Packet) {
 	if _, ok := processing[msgType][p.CHAddr().String()]; ok {
 		log.Printf("%s: ignore %s\n", p.CHAddr().String(), msgType.String())
 		return
+	}
+	if _, ok := processing[msgType]; !ok {
+		processing[msgType] = map[string]struct{}{}
 	}
 	processing[msgType][p.CHAddr().String()] = struct{}{}
 	switch msgType {

--- a/dhcp/server/handler.go
+++ b/dhcp/server/handler.go
@@ -1,0 +1,94 @@
+package server
+
+import (
+	"log"
+	"net"
+	"time"
+
+	dhcp "github.com/krolaw/dhcp4"
+)
+
+type Handler struct {
+	ServerIPAddr net.IP
+	Options      dhcp.Options
+	Leases       Leases
+	Change       func(*Lease) Reply
+}
+
+var processing = map[dhcp.MessageType]map[string]struct{}{}
+
+func init() {
+	processing[dhcp.Discover] = map[string]struct{}{}
+	processing[dhcp.Request] = map[string]struct{}{}
+}
+
+func (h *Handler) ServeDHCP(p dhcp.Packet, msgType dhcp.MessageType, options dhcp.Options) (replyPacket dhcp.Packet) {
+	if _, ok := processing[msgType][p.CHAddr().String()]; ok {
+		log.Printf("%s: ignore %s\n", p.CHAddr().String(), msgType.String())
+		return
+	}
+	processing[msgType][p.CHAddr().String()] = struct{}{}
+	switch msgType {
+	case dhcp.Discover:
+		lease := h.Leases.Get(p.CHAddr())
+		if lease == nil {
+			break
+		}
+		if h.Change != nil {
+			if reply := h.Change(lease); reply != nil {
+				replyPacket = reply.Packet(p, msgType, h, options[dhcp.OptionParameterRequestList])
+				break
+			}
+		}
+		replyPacket = dhcp.ReplyPacket(
+			p,
+			dhcp.Offer,
+			h.ServerIPAddr,
+			lease.IPAddr,
+			h.Leases.Duration,
+			h.Options.SelectOrderOrAll(options[dhcp.OptionParameterRequestList]),
+		)
+	case dhcp.Request:
+		if addr, ok := options[dhcp.OptionServerIdentifier]; ok && !net.IP(addr).Equal(h.ServerIPAddr) {
+			break
+		}
+		req := net.IP(options[dhcp.OptionRequestedIPAddress]).To4()
+		if req == nil {
+			req = net.IP(p.CIAddr()).To4()
+		}
+		if len(req) != 4 || req.Equal(net.IPv4zero) {
+			replyPacket = dhcp.ReplyPacket(p, dhcp.NAK, h.ServerIPAddr, nil, 0, nil)
+			break
+		}
+		i := dhcp.IPRange(h.Leases.StartIPAddr, req) - 1
+		if i < 0 || h.Leases.Range <= i {
+			replyPacket = dhcp.ReplyPacket(p, dhcp.NAK, h.ServerIPAddr, nil, 0, nil)
+			break
+		}
+		lease := h.Leases.Table[i]
+		if lease == nil {
+			replyPacket = dhcp.ReplyPacket(p, dhcp.NAK, h.ServerIPAddr, nil, 0, nil)
+			break
+		}
+		lease.Expiry = time.Now().Add(h.Leases.Duration)
+		if h.Change != nil {
+			if reply := h.Change(lease); reply != nil {
+				replyPacket = reply.Packet(p, msgType, h, options[dhcp.OptionParameterRequestList])
+				break
+			}
+		}
+		replyPacket = dhcp.ReplyPacket(
+			p,
+			dhcp.ACK,
+			h.ServerIPAddr,
+			req,
+			h.Leases.Duration,
+			h.Options.SelectOrderOrAll(options[dhcp.OptionParameterRequestList]),
+		)
+	case dhcp.Release, dhcp.Decline:
+		h.Leases.Delete(p.CHAddr())
+	}
+	delete(processing[msgType], p.CHAddr().String())
+	replyPacket.SetSIAddr(h.ServerIPAddr)
+	return
+}

--- a/dhcp/server/lease.go
+++ b/dhcp/server/lease.go
@@ -62,3 +62,9 @@ func (l *Lease) Find() {
 	}
 	l = tmp
 }
+
+func (l *Lease) Update() {
+	l.Expiry = time.Now().Add(l.leases.Duration)
+	i := dhcp.IPRange(l.leases.StartIPAddr, l.IPAddr) - 1
+	l.leases.Table[i] = l
+}

--- a/dhcp/server/lease.go
+++ b/dhcp/server/lease.go
@@ -55,12 +55,13 @@ func (l *Leases) Delete(addr net.HardwareAddr) {
 	}
 }
 
-func (l *Lease) Find() {
+func (l *Lease) Find() bool {
 	tmp := l.leases.Get(l.CHAddr)
 	if tmp == nil {
-		return
+		return false
 	}
 	*l = *tmp
+	return true
 }
 
 func (l *Lease) Update() {

--- a/dhcp/server/lease.go
+++ b/dhcp/server/lease.go
@@ -64,6 +64,9 @@ func (l *Lease) Find() {
 }
 
 func (l *Lease) Update() {
+	if l.leases.Table == nil {
+		l.leases.Initialize()
+	}
 	l.Expiry = time.Now().Add(l.leases.Duration)
 	i := dhcp.IPRange(l.leases.StartIPAddr, l.IPAddr) - 1
 	l.leases.Table[i] = l

--- a/dhcp/server/lease.go
+++ b/dhcp/server/lease.go
@@ -60,7 +60,7 @@ func (l *Lease) Find() {
 	if tmp == nil {
 		return
 	}
-	l = tmp
+	*l = *tmp
 }
 
 func (l *Lease) Update() {

--- a/dhcp/server/lease.go
+++ b/dhcp/server/lease.go
@@ -1,0 +1,54 @@
+package server
+
+import (
+	"bytes"
+	"net"
+	"time"
+
+	dhcp "github.com/krolaw/dhcp4"
+)
+
+type Leases struct {
+	StartIPAddr net.IP
+	Range       int
+	Duration    time.Duration
+	Table       []*Lease
+}
+
+type Lease struct {
+	CHAddr net.HardwareAddr
+	IPAddr net.IP
+	Expiry time.Time
+}
+
+func (l *Leases) Initialize() {
+	l.Table = make([]*Lease, l.Range)
+}
+
+func (l *Leases) Get(addr net.HardwareAddr) *Lease {
+	if l.Table == nil {
+		l.Initialize()
+	}
+	for i, lease := range l.Table {
+		if lease != nil && lease.Expiry.After(time.Now()) {
+			continue
+		}
+		lease = &Lease{
+			CHAddr: addr,
+			IPAddr: dhcp.IPAdd(l.StartIPAddr, i),
+			Expiry: time.Now().Add(l.Duration),
+		}
+		l.Table[i] = lease
+		return lease
+	}
+	return nil
+}
+
+func (l *Leases) Delete(addr net.HardwareAddr) {
+	for _, lease := range l.Table {
+		if bytes.Compare(lease.CHAddr, addr) == 0 {
+			lease = nil
+			break
+		}
+	}
+}

--- a/dhcp/server/lease.go
+++ b/dhcp/server/lease.go
@@ -19,6 +19,7 @@ type Lease struct {
 	CHAddr net.HardwareAddr
 	IPAddr net.IP
 	Expiry time.Time
+	leases *Leases
 }
 
 func (l *Leases) Initialize() {
@@ -37,6 +38,7 @@ func (l *Leases) Get(addr net.HardwareAddr) *Lease {
 			CHAddr: addr,
 			IPAddr: dhcp.IPAdd(l.StartIPAddr, i),
 			Expiry: time.Now().Add(l.Duration),
+			leases: l,
 		}
 		l.Table[i] = lease
 		return lease
@@ -51,4 +53,12 @@ func (l *Leases) Delete(addr net.HardwareAddr) {
 			break
 		}
 	}
+}
+
+func (l *Lease) Find() {
+	tmp := l.leases.Get(l.CHAddr)
+	if tmp == nil {
+		return
+	}
+	l = tmp
 }

--- a/dhcp/server/reply.go
+++ b/dhcp/server/reply.go
@@ -1,0 +1,57 @@
+package server
+
+import (
+	dhcp "github.com/krolaw/dhcp4"
+)
+
+type Reply interface {
+	Packet(dhcp.Packet, dhcp.MessageType, *Handler, []byte) dhcp.Packet
+	MergeOptions(dhcp.Options) dhcp.Options
+}
+
+type ACKReply struct {
+	Lease   *Lease
+	Options dhcp.Options
+}
+
+type NAKReply struct {
+}
+
+func (r *ACKReply) Packet(p dhcp.Packet, reqType dhcp.MessageType, h *Handler, req []byte) dhcp.Packet {
+	var msgType dhcp.MessageType
+	if reqType == dhcp.Discover {
+		msgType = dhcp.Offer
+	} else {
+		msgType = dhcp.ACK
+	}
+	return dhcp.ReplyPacket(
+		p,
+		msgType,
+		h.ServerIPAddr,
+		r.Lease.IPAddr,
+		h.Leases.Duration,
+		r.MergeOptions(h.Options).SelectOrderOrAll(req),
+	)
+}
+
+func (r *ACKReply) MergeOptions(options dhcp.Options) dhcp.Options {
+	res := make(dhcp.Options)
+	for k, v := range options {
+		res[k] = v
+	}
+	for k, v := range r.Options {
+		res[k] = v
+	}
+	return res
+}
+
+func (r *NAKReply) Packet(p dhcp.Packet, msgType dhcp.MessageType, h *Handler, _ []byte) dhcp.Packet {
+	if msgType == dhcp.Discover {
+		return nil
+	}
+	return dhcp.ReplyPacket(p, dhcp.NAK, h.ServerIPAddr, nil, 0, nil)
+}
+
+func (r *NAKReply) MergeOptions(_ dhcp.Options) dhcp.Options {
+	return nil
+}

--- a/dhcp/server/server.go
+++ b/dhcp/server/server.go
@@ -9,12 +9,12 @@ type Server struct {
 	Interface *string
 }
 
-func New(change func(*Lease) Reply) (*Server, error) {
+func New(handler func(*Lease) Reply) (*Server, error) {
 	config, err := NewConfig()
 	if err != nil {
 		return nil, err
 	}
-	return config.Server(change), nil
+	return config.Server(handler), nil
 }
 
 func (s *Server) Listen() error {

--- a/dhcp/server/server.go
+++ b/dhcp/server/server.go
@@ -1,0 +1,25 @@
+package server
+
+import (
+	dhcp "github.com/krolaw/dhcp4"
+)
+
+type Server struct {
+	Handler   *Handler
+	Interface *string
+}
+
+func New(change func(*Lease) Reply) (*Server, error) {
+	config, err := NewConfig()
+	if err != nil {
+		return nil, err
+	}
+	return config.Server(change), nil
+}
+
+func (s *Server) Listen() error {
+	if s.Interface == nil {
+		return dhcp.ListenAndServe(s.Handler)
+	}
+	return dhcp.ListenAndServeIf(*s.Interface, s.Handler)
+}


### PR DESCRIPTION
## WHY

起動するたびにIPアドレスが変わっていた。

## WHAT

貸出済みのIPアドレスを使わず新しいIPアドレスを発行していたのが原因。
2回目以降は前のIPアドレスを使うようにした。